### PR TITLE
Add a more optimised FixedGrid solution to spatial hashing

### DIFF
--- a/src/app/particle_sim_app.cc
+++ b/src/app/particle_sim_app.cc
@@ -8,11 +8,12 @@ void ParticleSimApp::Run()
 {
     sf::RenderWindow window{sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Particle Simulation", sf::Style::Titlebar | sf::Style::Close};
     sim::Container container{WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2};
-    sim::Renderer renderer{window};
-    sim::ParticleManager manager{container};
 
     // Center the container
     container.centerInside({0.0f, static_cast<float>(WINDOW_WIDTH)}, {0.0f, static_cast<float>(WINDOW_HEIGHT)});
+
+    sim::Renderer renderer{window};
+    sim::ParticleManager manager{container};
 
     window.setFramerateLimit(TARGET_FPS);
 
@@ -24,7 +25,7 @@ void ParticleSimApp::Run()
             if (event.type == sf::Event::Closed)
                 window.close();
 
-            if (event.type == sf::Event::MouseButtonPressed && event.mouseButton.button == sf::Mouse::Left)
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left))
             {
                 float x = event.mouseButton.x;
                 float y = event.mouseButton.y;
@@ -54,7 +55,7 @@ void ParticleSimApp::Run()
 
         renderer.drawContainer(container);
 
-        for (const auto& particle : deref_non_null_view(manager.particles()))
+        for (const auto& particle : manager.particles())
         {
             renderer.drawParticle(particle);
         }

--- a/src/common/constants.h
+++ b/src/common/constants.h
@@ -1,6 +1,8 @@
 #pragma once
 
-constexpr inline float G = 800.0f;
-constexpr inline float DAMPING_CONSTANT = 0.85f;
-constexpr inline float MAX_VEL = 450.0f;
-constexpr inline float MAX_RADIUS = 30.0f;
+namespace sim {
+    constexpr inline float G = 800.0f;
+    constexpr inline float DAMPING_CONSTANT = 0.85f;
+    constexpr inline float MAX_VEL = 500.0f;
+    constexpr inline float MAX_RADIUS = 30.0f;
+}

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,16 +1,11 @@
 #pragma once
-#include <ranges>
+#include <random>
 
-template <typename Range>
-auto non_null_view(Range&& range)
+inline float generateRandomFloat(float min, float max)
 {
-    return range
-           | std::views::filter([](const auto& p) { return p != nullptr; });
-}
+    std::random_device rd;
+    std::mt19937 gen(rd());
 
-template <typename Range>
-auto deref_non_null_view(Range&& range)
-{
-    return non_null_view(range)
-           | std::views::transform([](const auto& p) -> decltype(auto) { return *p; });
+    std::uniform_real_distribution<float> dis(min, max);
+    return dis(gen);
 }

--- a/src/include/doubly_linked_list.h
+++ b/src/include/doubly_linked_list.h
@@ -1,0 +1,321 @@
+#include <utility>
+#include <cstddef>
+#include <cassert>
+#include <iterator>
+
+
+template <typename ItemType>
+class double_linked_list
+{
+public:
+    // ----------------------------------------
+    // |               aliases                |
+    // ----------------------------------------
+    using      value_type = ItemType;
+    using       size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using         pointer = value_type *;
+    using   const_pointer = const value_type *;
+    using       reference = value_type &;
+    using const_reference = const value_type &;
+
+    // ----------------------------------------
+    // |               list node              |
+    // ----------------------------------------
+    struct node
+    {
+        node* next = nullptr;
+        node* prev = nullptr;
+        value_type val;
+
+        node(value_type item) noexcept
+            : val{std::move(item)}
+        {
+        }
+    };
+
+    // ----------------------------------------
+    // |            const iterator            |
+    // ----------------------------------------
+    class double_linked_list_const_iterator
+    {
+    private:
+        explicit double_linked_list_const_iterator(const node* ptr) noexcept
+            : m_current{ ptr }
+        {
+        }
+
+        friend class double_linked_list;
+
+    public:
+        using   difference_type = double_linked_list::difference_type;
+        using        value_type = double_linked_list::value_type;
+        using           pointer = double_linked_list::const_pointer;
+        using         reference = double_linked_list::const_reference;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        reference operator*() const noexcept
+        {
+            assert(m_current != nullptr);
+            return m_current->val;
+        }
+
+        double_linked_list_const_iterator& operator++() noexcept
+        {
+            assert(m_current != nullptr);
+            m_current = m_current->next;
+            return *this;
+        }
+
+        double_linked_list_const_iterator& operator--() noexcept
+        {
+            assert(m_current != nullptr);
+            m_current = m_current->prev;
+            return *this;
+        }
+
+        double_linked_list_const_iterator operator++(int) noexcept
+        {
+            assert(m_current != nullptr);
+            auto copy = *this;
+            m_current = m_current->next;
+            return copy;
+        }
+
+        double_linked_list_const_iterator operator--(int) noexcept
+        {
+            assert(m_current != nullptr);
+            auto copy = *this;
+            m_current = m_current->prev;
+            return copy;
+        }
+
+        bool operator==(double_linked_list_const_iterator other) const noexcept
+        {
+            return m_current == other.m_current;
+        }
+
+        bool operator!=(double_linked_list_const_iterator other) const noexcept
+        {
+            return !(*this == other);
+        }
+
+    protected:
+        const node* Get() const noexcept
+        {
+            return m_current;
+        }
+
+    protected:
+        const node* m_current;
+    };
+
+    // ----------------------------------------
+    // |               iterator               |
+    // ----------------------------------------
+    class double_linked_list_iterator : public double_linked_list_const_iterator
+    {
+    private:
+        explicit double_linked_list_iterator(node* ptr) noexcept
+            : double_linked_list_const_iterator{ ptr }
+        {
+        }
+
+        friend class double_linked_list;
+
+    public:
+        using   difference_type = double_linked_list::difference_type;
+        using        value_type = double_linked_list::value_type;
+        using           pointer = double_linked_list::pointer;
+        using         reference = double_linked_list::reference;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        reference operator*() noexcept
+        {
+            return const_cast<reference>(double_linked_list_const_iterator::operator*());
+        }
+
+        double_linked_list_iterator& operator++() noexcept
+        {
+            double_linked_list_const_iterator::operator++();
+            return *this;
+        }
+
+        double_linked_list_iterator& operator--() noexcept
+        {
+            double_linked_list_const_iterator::operator--();
+            return *this;
+        }
+
+        double_linked_list_iterator operator++(int) noexcept
+        {
+            auto res = double_linked_list_const_iterator::operator++(0);
+            return double_linked_list_iterator{
+                const_cast<node*>(res.Get())
+            };
+        }
+
+        double_linked_list_iterator operator--(int) noexcept
+        {
+            auto res = double_linked_list_const_iterator::operator--(0);
+            return double_linked_list_iterator{
+                const_cast<node*>(res.Get())
+            };
+        }
+    };
+
+    using       iterator = double_linked_list_iterator;
+    using const_iterator = double_linked_list_iterator;
+
+    // ----------------------------------------
+    // |      constructors/destructors        |
+    // ----------------------------------------
+    double_linked_list() = default;
+
+    double_linked_list(std::initializer_list<value_type> items)
+    {
+        for (auto& item : items)
+        {
+            push_back(item);
+        }
+    }
+
+    ~double_linked_list()
+    {
+        clear();
+    }
+
+    void clear() noexcept
+    {
+        while (m_head)
+        {
+            delete std::exchange(m_head, m_head->next);
+        }
+
+        m_tail = nullptr;
+    }
+
+    // ----------------------------------------
+    // |               insertion              |
+    // ----------------------------------------
+    void push_back(value_type item)
+    {
+        auto new_node = new node{ std::move(item) };
+
+        if (m_tail)
+        {
+            m_tail->next = new_node;
+            new_node->prev = m_tail;
+            m_tail = new_node;
+        }
+        else
+        {
+            m_tail = m_head = new_node;
+        }
+    }
+
+    void push_front(value_type item)
+    {
+        auto new_node = new node{ std::move(item) };
+
+        if (m_head)
+        {
+            m_head->prev = new_node;
+            new_node->next = m_head;
+            m_head = new_node;
+        }
+        else
+        {
+            m_head = m_tail = new_node;
+        }
+    }
+
+    // ----------------------------------------
+    // |              traversal               |
+    // ----------------------------------------
+    const_iterator begin() const noexcept
+    {
+        return const_iterator{ m_head };
+    }
+
+    const_iterator end() const noexcept
+    {
+        return const_iterator{ nullptr };
+    }
+
+    const_iterator cbegin() const noexcept
+    {
+        return const_iterator{ m_head };
+    }
+
+    const_iterator cend() const noexcept
+    {
+        return const_iterator{ nullptr};
+    }
+
+    iterator begin() noexcept
+    {
+        return iterator{ m_head };
+    }
+
+    iterator end() noexcept
+    {
+        return iterator{ nullptr };
+    }
+
+    // ----------------------------------------
+    // |                search                |
+    // ----------------------------------------
+    const_iterator find(const_reference item) const noexcept
+    {
+        for (auto it = begin(); it != end(); ++it)
+        {
+            if (*it == item)
+            {
+                return it;
+            }
+        }
+
+        return const_iterator{ nullptr };
+    }
+
+    iterator find(const_reference item) noexcept
+    {
+        auto it = static_cast<const double_linked_list &>(*this).find(item);
+        return iterator{ const_cast<node*>(it.Get()) };
+    }
+
+
+    // ----------------------------------------
+    // |                deletion              |
+    // ----------------------------------------
+    void erase(const_iterator place) noexcept
+    {
+        auto ptr = const_cast<node*>(place.Get());
+        assert(ptr != nullptr);
+
+        if (ptr->prev)
+        {
+            ptr->prev->next = ptr->next;
+        }
+        else
+        {
+            m_head = ptr->next;
+        }
+
+        if (ptr->next)
+        {
+            ptr->next->prev = ptr->prev;
+        }
+        else
+        {
+            m_tail = ptr->prev;
+        }
+
+        delete ptr;
+    }
+
+private:
+    node* m_head = nullptr;
+    node* m_tail = nullptr;
+};

--- a/src/physics/fixed_grid.cc
+++ b/src/physics/fixed_grid.cc
@@ -1,0 +1,86 @@
+#include "fixed_grid.h"
+
+namespace sim {
+
+FixedGrid::FixedGrid(const Vec2f& top_left, const Vec2f& bottom_right)
+    : top_left_{top_left}
+    , bottom_right_{bottom_right}
+{
+    rows_ = ( bottom_right_.y - top_left_.y ) / CELL_SIZE;
+    cols_ = ( bottom_right_.x - top_left_.x ) / CELL_SIZE;
+    grid_.resize(rows_ * cols_);
+}
+
+Vec2i FixedGrid::getCell(const Vec2f& position)
+{
+    const Vec2f rel_pos = position - top_left_;
+    const uint8_t c = rel_pos.x / CELL_SIZE;
+    const uint8_t r = rel_pos.y / CELL_SIZE;
+    return Vec2i{r, c};
+}
+
+size_t FixedGrid::getIndex(const Vec2i& cell)
+{
+    return cell[0] * cols_ + cell[1];
+}
+
+void FixedGrid::add(Particle& entity)
+{
+    const Vec2i cell = getCell(entity.position());
+    entity.setRegion(cell);
+    const auto idx = getIndex(cell);
+    grid_[idx].push_back(entity.id());
+}
+
+void FixedGrid::remove(Particle& entity)
+{
+    const Vec2i cell = entity.region();
+    const auto idx = getIndex(cell);
+    auto it = grid_[idx].find(entity.
+    id());
+    grid_[idx].erase(it);
+}
+
+std::vector<Particle::id_type> FixedGrid::getNearby(Particle& entity)
+{
+    std::vector<Particle::id_type> neighbours;
+
+    const Vec2i cell = entity.region();
+
+    // This loop adds all neighbours from top-left, top, left and same cell
+    for (int dx = -1; dx <= 0; ++dx)
+    {
+        for (int dy = -1; dy <= 0; ++dy)
+        {
+            const Vec2i new_cell = cell + Vec2i{dx, dy};
+            if (new_cell.x < 0 || new_cell.x >= rows_ || new_cell.y < 0 || new_cell.y >= cols_)
+            {
+                continue;
+            }
+
+            const auto idx = getIndex(new_cell);
+
+            for (const auto id : grid_[idx])
+            {
+                if (id == entity.id()) { continue; }
+                neighbours.push_back(id);
+            }
+        }
+    }
+
+    // Add neighbours from bottom-left cell
+    const Vec2i bl_cell{cell.x + 1, cell.y - 1};
+    if (bl_cell.x < rows_ && bl_cell.y > 0)
+    {
+        const auto idx = getIndex(bl_cell);
+        for (const auto id : grid_[idx])
+            {
+                neighbours.push_back(id);
+            }
+    }
+
+    return neighbours;
+}
+
+
+}

--- a/src/physics/fixed_grid.h
+++ b/src/physics/fixed_grid.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "common/constants.h"
+#include "include/doubly_linked_list.h"
+
+#include "spatial_partitioner.h"
+#include "particle.h"
+
+namespace sim {
+
+class FixedGrid : public SpatialPartitioner<Particle, Particle::id_type>
+{
+public:
+    FixedGrid() = default;
+    FixedGrid(const Vec2f& top_left, const Vec2f& bottom_right);
+
+    void add(Particle& entity) override;
+    void remove(Particle& entity) override;
+    std::vector<Particle::id_type> getNearby(Particle& entity) override;
+
+private:
+    Vec2i getCell(const Vec2f& position);
+    size_t getIndex(const Vec2i& cell);
+
+private:
+    using StoreType = std::vector<double_linked_list<Particle::id_type>>;
+    StoreType grid_;
+    Vec2f top_left_{0.0f, 0.0f};
+    Vec2f bottom_right_{0.0f, 0.0f};
+
+    uint8_t rows_{0};
+    uint8_t cols_{0};
+
+    static constexpr uint8_t CELL_SIZE = static_cast<uint8_t>(2 * MAX_RADIUS);
+
+};
+
+}

--- a/src/physics/particle.cc
+++ b/src/physics/particle.cc
@@ -2,18 +2,16 @@
 #include <algorithm>
 #include <ranges>
 
-#include "common/utils.h"
 #include "particle.h"
 
 namespace sim {
 
 int Particle::nextID = 0;
 
-Particle::Particle(const Vec2f& position, int region, float radius)
+Particle::Particle(const Vec2f& position, float radius)
     : position_{position}
     , acceleration_{0, G}
     , radius_{radius}
-    , region_{region}
     , id_{nextID++}
 {
 }

--- a/src/physics/particle.h
+++ b/src/physics/particle.h
@@ -18,13 +18,9 @@ public:
     static const sf::Color fastColour;
     static const sf::Color midColour;
 
-    Particle(const Vec2f& position, int grid_loc, float radius = 10.0f);
+    using id_type = uint16_t;
 
-    // It doesn't make sense to copy/move particles to other particles
-    Particle(const Particle& other) = delete;
-    Particle& operator=(const Particle& other) = delete;
-    Particle(Particle&& other) noexcept = delete;
-    Particle& operator=(Particle&& other) = delete;
+    Particle(const Vec2f& position, float radius = 10.0f);
 
     const Vec2f& nextPosition(float timestep);
 
@@ -62,12 +58,12 @@ public:
         acceleration_ = accel;
     }
 
-    void setRegion(int region)
+    void setRegion(const Vec2i& region)
     {
         region_ = region;
     }
 
-    int region() const
+    const Vec2i& region() const
     {
         return region_;
     }
@@ -106,7 +102,7 @@ private:
     Vec2f velocity_;
     float radius_;
     float mass_;
-    int region_;
+    Vec2i region_;
     int id_;
 };
 

--- a/src/physics/particle_manager.cc
+++ b/src/physics/particle_manager.cc
@@ -7,58 +7,34 @@ namespace sim {
 ParticleManager::ParticleManager(Container& container)
     : container_{container}
 {
+    const auto& [x_bounds, y_bounds] = container_.getBounds();
+    const Vec2f top_left{x_bounds[0], y_bounds[0]};
+    const Vec2f bottom_right{x_bounds[1], y_bounds[1]};
+    partitioner_ = FixedGrid{top_left, bottom_right};
 }
 
 const Particle& ParticleManager::createParticleAtCursor(float x, float y)
 {
-    const float radius = 10.0f;
+    const float radius = generateRandomFloat(5.0f, 20.0f);
     const auto& [x_bounds, y_bounds] = container_.getBounds(radius);
     const auto& [x_min, x_max] = x_bounds;
     const auto& [y_min, y_max] = y_bounds;
 
-
     Vec2f position{x, y};
     position.clamp({x_min, x_max}, {y_min, y_max});
 
-    // We maintain a spatial grid and particles inside it for easier collision handling
-    auto cell = computeFlattenedLocation(position);
-    auto region = computeRegion(position);
-    auto new_particle = std::make_unique<Particle>(position, region, radius);
-    particle_store_[cell] = std::move(new_particle);
+    Particle p{position, radius};
+    partitioner_.add(p);
+    particles_.push_back(std::move(p));
 
-    return *particle_store_[cell];
-}
-
-int ParticleManager::computeRegion(const Vec2f& position)
-{
-    const auto& [x_bounds, y_bounds] = container_.getBounds();
-    const auto& [x_min, x_max] = x_bounds;
-    const auto& [y_min, y_max] = y_bounds;
-
-    const auto hash_row = int((position.y - y_min) / (container_.getHeight() / GRID_SIZE));
-    const auto hash_col = int((position.x - x_min) / (container_.getWidth() / GRID_SIZE));
-    return hash_row * GRID_SIZE + hash_col;
-}
-
-int ParticleManager::computeFlattenedLocation(const Vec2f& position)
-{
-    const auto region_start = computeRegion(position) * MAX_PER_CELL;
-
-    int cell = region_start;
-    while (particle_store_[cell])
-    {
-        cell++;
-    }
-
-    // When the number of particles in a cell exceeds MAX_PER_CELL, we simply overwrite the last one.
-    return std::clamp(cell, region_start, region_start + MAX_PER_CELL - 1);
+    return particles_.back();
 }
 
 void ParticleManager::updateParticles(float dt)
 {
     updateGrid();
 
-    for (auto& particle : deref_non_null_view(particle_store_))
+    for (auto& particle : particles_)
     {
         particle.setAcceleration(Vec2f{0, G});
         resolveCollisions(particle);
@@ -70,18 +46,10 @@ void ParticleManager::updateParticles(float dt)
 void ParticleManager::updateGrid()
 {
     // Move particles to their new regions
-    for (auto& particle : non_null_view(particle_store_))
+    for (auto& particle : particles_)
     {
-        const auto old_region = particle->region();
-        const auto new_region = computeRegion(particle->position());
-
-        if (old_region != new_region)
-        {
-            particle->setRegion(new_region);
-
-            const auto new_cell = computeFlattenedLocation(particle->position());
-            particle_store_[new_cell] = std::move(particle);
-        }
+        partitioner_.remove(particle);
+        partitioner_.add(particle);
     }
 }
 
@@ -111,46 +79,36 @@ void ParticleManager::resolveOutOfBounds(Particle& particle)
 
 void ParticleManager::resolveCollisions(Particle& particle)
 {
-    const auto region = particle.region();
+    auto neighbours = partitioner_.getNearby(particle);
 
-    for (auto offset : neighbour_offsets_)
+    for (auto nbr : neighbours)
     {
-        auto curr_region_start = (region + offset) * MAX_PER_CELL;
+        Particle& other = particles_[nbr];
+        const auto axis = particle.position() - other.position();
+        const auto dist2 = vec_dot(axis, axis);
+        const auto min_dist = particle.radius() + other.radius();
 
-        for (int i = curr_region_start; i < curr_region_start + MAX_PER_CELL; i++)
+        if (dist2 > min_dist * min_dist)
         {
-            if (i >= particle_store_.size() || !particle_store_[i] || *particle_store_[i] == particle)
-            {
-                continue;
-            }
-
-            auto& neighbour = *particle_store_[i];
-            const auto axis = particle.position() - neighbour.position();
-            const auto dist2 = vec_dot(axis, axis);
-            const auto min_dist = particle.radius() + neighbour.radius();
-
-            if (dist2 > min_dist * min_dist)
-            {
-                continue;
-            }
-
-            const auto dist = std::sqrt(dist2);
-            Vec2f norm = axis / dist;
-            const float delta = 0.5 * std::abs(dist - min_dist);
-            particle.move(norm * delta);
-            neighbour.move(norm * -delta);
-
-            // Assuming mass is equal
-            Vec2f delta_vel = vec_dot(norm, particle.velocity() - neighbour.velocity()) * norm ;
-            particle.changeVelocity(-delta_vel);
-            neighbour.changeVelocity(delta_vel);
+            continue;
         }
+
+        const auto dist = std::sqrt(dist2);
+        Vec2f norm = axis / dist;
+        const float delta = 0.5 * std::abs(dist - min_dist);
+        particle.move(norm * delta);
+        other.move(norm * -delta);
+
+        // Assuming mass is equal
+        Vec2f delta_vel = vec_dot(norm, particle.velocity() - other.velocity()) * norm ;
+        particle.changeVelocity(-delta_vel);
+        other.changeVelocity(delta_vel);
     }
 }
 
 const ParticleManager::ParticleStore& ParticleManager::particles() const
 {
-    return particle_store_;
+    return particles_;
 }
 
 }

--- a/src/physics/particle_manager.h
+++ b/src/physics/particle_manager.h
@@ -2,16 +2,14 @@
 #include <array>
 #include <memory>
 #include "particle.h"
+#include "fixed_grid.h"
 
 namespace sim {
 
 class ParticleManager
 {
 public:
-    static constexpr int GRID_SIZE = 8;
-    static constexpr int MAX_PER_CELL = 5;
-
-    using ParticleStore = std::array<std::unique_ptr<Particle>, GRID_SIZE * GRID_SIZE * MAX_PER_CELL>;
+    using ParticleStore = std::vector<Particle>;
 
     ParticleManager(Container& container);
 
@@ -25,27 +23,12 @@ public:
     const ParticleStore& particles() const;
 
 private:
-    int computeRegion(const Vec2f& position);
-    int computeFlattenedLocation(const Vec2f& position);
-
     using BoundsType = std::pair<Vec2f, Vec2f>;
     BoundsType getMinMaxBounds();
 
-    ParticleStore particle_store_;
-
+    FixedGrid partitioner_;
+    ParticleStore particles_;
     Container& container_;
-
-    std::array<int, 9> neighbour_offsets_ = {
-        -GRID_SIZE - 1,
-            -GRID_SIZE,
-        -GRID_SIZE + 1,
-                    -1,
-                     0,
-                     1,
-         GRID_SIZE - 1,
-             GRID_SIZE,
-         GRID_SIZE + 1,
-    };
 };
 
 }

--- a/src/physics/spatial_partitioner.h
+++ b/src/physics/spatial_partitioner.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+
+namespace sim {
+class Particle;
+
+template <typename InfoType, typename ValueType>
+class SpatialPartitioner
+{
+public:
+    virtual void add(InfoType& entity) = 0;
+    virtual void remove(InfoType& entity) = 0;
+    virtual std::vector<ValueType> getNearby(InfoType& entity) = 0;
+};
+
+}


### PR DESCRIPTION
Previously we had a naive ```std::array``` which was a flattened representation of a 3D spatial grid where the first two dimensions identified the row/column coordinate of the cell a particle was located in. The third dimension was just used to store multiple particles. However, this was far too much memory required so the program could only handle 5 particles in any one spatial grid cell.

The new approach is as follows:

- A ```std::vector``` stores all the particles in the simulation, for trivial traversal
- The spatial grid is implemented as a fixed size grid, which contains doubly linked lists in each cell. The linked lists keep track of all the particles in the cell. The outer grid is represented by a ```std::vector```. The linked lists store the id value for each particle instead of storing pointers/particles themselves. The id of each particle can be used to figure out where in the particles vector the particular particle is stored in.